### PR TITLE
Disabled option to archive to local PST files

### DIFF
--- a/business.xml
+++ b/business.xml
@@ -15,6 +15,7 @@
     <User Key="software\microsoft\office\16.0\outlook\options\mail" Name="junkmailprotection" Value="6" Type="REG_DWORD" App="outlk16" Id="L_JunkEmailprotectionlevel" />
     <User Key="software\microsoft\office\16.0\outlook\options\general" Name="check default client" Value="1" Type="REG_DWORD" App="outlk16" Id="L_MakeOutlookthedefaultprogramforEmailContactsandCalendar" />
     <User Key="software\microsoft\office\16.0\outlook\options\mail" Name="unblockspecificsenders" Value="1" Type="REG_DWORD" App="outlk16" Id="L_PermitdownloadofcontentfromSafeSenderandRecipientlists" />
+    <User Key="software\microsoft\office\16.0\outlook\preferences" Name="disablemanualarchive" Value="1" Type="REG_DWORD" App="outlk16" Id="L_DisableFileArchive" />
     <User Key="software\microsoft\office\outlook\socialconnector" Name="runosc" Value="0" Type="REG_DWORD" App="outlk16" Id="L_TurnOffOutlookSocialConnector" />
     <User Key="software\microsoft\office\16.0\word\security" Name="blockcontentexecutionfrominternet" Value="1" Type="REG_DWORD" App="word16" Id="L_BlockMacroExecutionFromInternet" />
   </AppSettings>

--- a/proplus.xml
+++ b/proplus.xml
@@ -16,6 +16,7 @@
   <AppSettings>
     <User Key="software\microsoft\office\16.0\outlook\options\mail" Name="junkmailprotection" Value="6" Type="REG_DWORD" App="outlk16" Id="L_JunkEmailprotectionlevel" />
     <User Key="software\microsoft\office\16.0\outlook\options\general" Name="check default client" Value="1" Type="REG_DWORD" App="outlk16" Id="L_MakeOutlookthedefaultprogramforEmailContactsandCalendar" />
+    <User Key="software\microsoft\office\16.0\outlook\preferences" Name="disablemanualarchive" Value="1" Type="REG_DWORD" App="outlk16" Id="L_DisableFileArchive" />
     <User Key="software\microsoft\office\16.0\outlook\options\mail" Name="unblockspecificsenders" Value="1" Type="REG_DWORD" App="outlk16" Id="L_PermitdownloadofcontentfromSafeSenderandRecipientlists" />
     <User Key="software\microsoft\office\outlook\socialconnector" Name="runosc" Value="0" Type="REG_DWORD" App="outlk16" Id="L_TurnOffOutlookSocialConnector" />
     <User Key="software\microsoft\office\16.0\word\security" Name="blockcontentexecutionfrominternet" Value="1" Type="REG_DWORD" App="word16" Id="L_BlockMacroExecutionFromInternet" />


### PR DESCRIPTION
For clients who have online archiving enabled, they should not be given an option to locally archive to a PST file. I've added a preference to disable this option in Outlook.